### PR TITLE
Fix SASS path handling for cross-platform compatibility and update social links

### DIFF
--- a/gulp-tasks/sass.js
+++ b/gulp-tasks/sass.js
@@ -17,8 +17,8 @@ const calculateOutput = ({history}) => {
     // HTML can grab it with a <link />
     let response = './dist/css';
 
-    // Get everything after the last slash
-    const sourceFileName = isProduction ? /[^/]*$/.exec(history[0])[0] : /[^\\]*$/.exec(history[0])[0];
+    // Get everything after the last slash (handles both forward and backward slashes)
+    const sourceFileName = /[^/\\]*$/.exec(history[0])[0];
 
     // If this is critical CSS though, we want it to go
     // to the _includes directory, so nunjucks can include it

--- a/src/_includes/layouts/base.html
+++ b/src/_includes/layouts/base.html
@@ -46,6 +46,8 @@
     <link href="https://www.instagram.com/oerlemanstim/" rel="me">
     <link href="https://www.last.fm/user/TimOerlemans" rel="me">
     <link href="https://steamcommunity.com/id/timoerlemans/" rel="me">
+    <link href="https://oerlemans.substack.com" rel="me">
+    <link href="https://bsky.app/profile/groenoranjerood.bsky.social" rel="me">
     <link rel="authorization_endpoint" href="https://indieauth.com/auth">
     <link rel="webmention" href="https://webmention.io/tim.oerlemans.dev/webmention" />
     <link rel="pingback" href="https://webmention.io/tim.oerlemans.dev/xmlrpc" />

--- a/src/index.md
+++ b/src/index.md
@@ -9,4 +9,4 @@ Currently, I'm doing just that while working at [Van Spaendonck Development](htt
 
 In the past, I worked at [Handpicked Agencies](https://www.handpickedagencies.com/en) and [Truelime](https://www.truelime.nl/).
 
-If you want to connect with me, you can find me on [Mastodon](https://mastodon.social/@oerlemans), [LinkedIn](https://www.linkedin.com/in/timoerlemans/), [Github](https://www.github.com/timoerlemans/) or you can send me an old-fashioned e-mail (tim[at]oerlemans[dot]dev).
+If you want to connect with me, you can find me on [Substack](https://oerlemans.substack.com), [Bluesky](https://bsky.app/profile/groenoranjerood.bsky.social), [Mastodon](https://mastodon.social/@oerlemans), [LinkedIn](https://www.linkedin.com/in/timoerlemans/), [Github](https://www.github.com/timoerlemans/) or you can send me an old-fashioned e-mail (tim[at]oerlemans[dot]dev).


### PR DESCRIPTION
## Summary

- Fix regex in `gulp-tasks/sass.js` to handle both forward and backward slashes, resolving build failures on Linux where critical CSS files (`critical.css`, `base.css`) were incorrectly output to `dist/css/` instead of `src/_includes/css/`
- Add Substack and Bluesky profile links to base layout and index page

## Test plan

- [ ] Run `npm run start` and verify no build errors
- [ ] Confirm `src/_includes/css/critical.css` and `src/_includes/css/base.css` are created
- [ ] Verify site loads correctly at http://localhost:8080
- [ ] Check that new social links appear on homepage

🤖 Generated with [Claude Code](https://claude.ai/code)