### PR TITLE
Fix blog post chronological sorting

### DIFF
--- a/src/_utils/sort-blogposts-by-date.js
+++ b/src/_utils/sort-blogposts-by-date.js
@@ -1,7 +1,7 @@
 module.exports = (collection) => collection.getFilteredByGlob('./src/blog/*/**/*.md')
         .sort((a, b) => {
-            const aDate = new Date(a.date.postDate);
-            const bDate = new Date(b.date.postDate);
-            return +aDate - +bDate;
+            const aDate = new Date(a.data.postDate);
+            const bDate = new Date(b.data.postDate);
+            return aDate - bDate;
         });
 


### PR DESCRIPTION
## Summary
- Fixed blog post sorting on the blog overview page by correcting the Eleventy data property access
- Changed `a.date.postDate` to `a.data.postDate` in the sort function
- Posts now correctly display from newest to oldest

## Test plan
- [x] Build the site locally with `npm run build` or `npm run dev`
- [x] Navigate to the blog overview page
- [x] Verify posts are sorted chronologically from newest to oldest

🤖 Generated with [Claude Code](https://claude.com/claude-code)