### PR TITLE
[fix] Add rel="noopener noreferrer" to external links

### DIFF
--- a/src/_includes/layouts/base.html
+++ b/src/_includes/layouts/base.html
@@ -89,11 +89,11 @@
                     for everyone, and therefore I'm trying to make it as accessible and user-friendly as possible.
                 </p>
                 <p>Currently, I'm doing just that while working at <a href="https://www.vanspaendonck.nl/"
-                                                                      rel="noreferrer"
+                                                                      rel="noopener noreferrer"
                                                                       target="_blank">Van Spaendonck Development</a> in
-                    Tilburg, where I work on products like <a href="https://www.loket.nl/" rel="noreferrer"
+                    Tilburg, where I work on products like <a href="https://www.loket.nl/" rel="noopener noreferrer"
                                                               target="_blank">Loket</a>
-                    and <a href="https://www.clever.nl/" rel="noreferrer" target="_blank">Clever</a>.
+                    and <a href="https://www.clever.nl/" rel="noopener noreferrer" target="_blank">Clever</a>.
                 </p>
             {% endblock %}
         </div>

--- a/src/blog/2024/onbevooroordeelde-nieuwsgierigheid.md
+++ b/src/blog/2024/onbevooroordeelde-nieuwsgierigheid.md
@@ -7,7 +7,7 @@ postDate: '2024-04-30'
 
 Afgelopen vrijdag ging ik, samen met mijn jongste zoon Guus, mijn oudste zoon Jip ophalen bij de BSO. Ondanks dat het schoolvakantie was, waren er nog maar drie andere kinderen en één pedagogisch medewerker aanwezig.
 
-Een van de kinderen was een jongen van een jaar of negen. Toen ik Guus in zijn [rolstoelbuggy](https://www.etac.com/nl-nl/nederlands/Hulpmiddelen/kinderen-en-jongvolwassenen/zitten/r82-stingray/){target="_blank"} het lokaal binnenreed, keek die jongen al erg nieuwsgierig naar Guus. Na een tijdje stelde hij de vraag die mij in mijn hoofd al duizend keer is gesteld, maar nog nooit in het echt.
+Een van de kinderen was een jongen van een jaar of negen. Toen ik Guus in zijn [rolstoelbuggy](https://www.etac.com/nl-nl/nederlands/Hulpmiddelen/kinderen-en-jongvolwassenen/zitten/r82-stingray/){target="_blank" rel="noopener noreferrer"} het lokaal binnenreed, keek die jongen al erg nieuwsgierig naar Guus. Na een tijdje stelde hij de vraag die mij in mijn hoofd al duizend keer is gesteld, maar nog nooit in het echt.
 
 "Is het niet wat overdreven dat zo'n grote jongen nog in een kinderwagen zit?" vroeg hij. Het klonk wat brutaal, maar het was duidelijk nieuwsgierigheid die hem de vraag deed stellen. Hoewel ik dit gesprek al duizend keer in mijn hoofd had gevoerd, moest ik toch even nadenken over het antwoord, vooral omdat de vraag zo onverwacht kwam.
 


### PR DESCRIPTION
## Summary
- Added `noopener` to `rel` attribute on 3 external links in `src/_includes/layouts/base.html` (Van Spaendonck, Loket, Clever)
- Added `rel="noopener noreferrer"` to 1 external link in `src/blog/2024/onbevooroordeelde-nieuwsgierigheid.md`

This prevents tab-napping attacks and referrer leakage for all external links that open in new tabs.

Fixes #148

## Test plan
- [x] Run `npm run production` to build the site
- [x] Verify generated HTML contains the updated rel attributes
- [ ] Open the site locally and inspect the links in DevTools

🤖 Generated with [Claude Code](https://claude.com/claude-code)