### PR TITLE
[fix] Add Node.js engines field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
+  "engines": {
+    "node": ">=18.0.0"
+  },
   "dependencies": {
     "@11ty/eleventy": "^3.0.0",
     "concurrently": "^9.0.0",


### PR DESCRIPTION
## Summary
- Adds `engines` field to package.json specifying Node.js >= 18.0.0
- Ensures npm/yarn warns users if they're using an incompatible Node.js version
- Required for ESLint 9.x, Eleventy 3.x, and other modern dependencies

Closes #154

## Test plan
- [x] `node -e "JSON.parse(require('fs').readFileSync('package.json'))"` - package.json is valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)