### PR TITLE
[docs] Document html:true decision in markdown-it config

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -21,6 +21,8 @@ module.exports = config => {
         return format(date, dateFormat);
     });
 
+    // html: true is intentional - content is trusted (site owner only)
+    // Required for: Nunjucks templating in .md files and markdown-it-attrs plugin
     const mdOptions = {
         html: true,
         breaks: true,


### PR DESCRIPTION
## Summary
Documents the intentional use of `html: true` in markdown-it configuration to address security review concerns.

**Why html:true is safe here:**
- All markdown content is from a trusted source (site owner only)
- No user-submitted content is processed through markdown-it
- Required for Nunjucks templating within `.md` files
- Required for `markdown-it-attrs` plugin functionality

Closes #149

## Test plan
- [x] `npm run production` builds successfully
- [x] Site functionality unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)