### PR TITLE
[security] Add SRI hash to external scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [Unreleased]
+
+### Security
+- Add SRI hashes to external scripts (#150)
+- Replace WebFont loader with native CSS font-loading (#151)
+
+### Fixed
+- Fix typo 'delare' to 'declare' in comment (#146)
+
+### Changed
+- Use modern ::before/::after pseudo-element syntax (#143)
+- Improve HTML template formatting (#144)
+- Remove empty webfontloader.js file (#145)
+- Migrate from CommonJS to ES modules (#155)
+- Remove unnecessary vendor prefixes (#156)
+- Add CSS spacing custom properties (#158)

--- a/src/_includes/layouts/base.html
+++ b/src/_includes/layouts/base.html
@@ -104,7 +104,7 @@
         <span class="slider round"></span>
     </label>
 </div>
-<script src="https://ajax.googleapis.com/ajax/libs/webfont/1.6.26/webfont.js"></script>
+<script src="https://ajax.googleapis.com/ajax/libs/webfont/1.6.26/webfont.js" integrity="sha384-pvXSwSU09c+q9mPyY++ygUHWIYRoaxgnJ/JC5wcOzMb/NVVu+IDniiB9qWp3ZNWM" crossorigin="anonymous"></script>
 <script>
     WebFont.load({
         custom: {


### PR DESCRIPTION
## Summary
- Add Subresource Integrity (SRI) hash to the Google WebFont loader script for enhanced security
- Skipping Umami analytics script as it may change frequently and would break analytics

## Test plan
- [ ] Verify the site loads correctly with fonts rendering properly
- [ ] Check browser console for no SRI-related errors
- [ ] Confirm the WebFont script is loaded with integrity check

Fixes #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)