### PR TITLE
[fix] Fix typo 'delare' to 'declare'

### DIFF
--- a/src/_includes/layouts/base.html
+++ b/src/_includes/layouts/base.html
@@ -24,7 +24,7 @@
     <style>{% include "css/critical.css" %}</style>
     <style>{% include "css/base.css" %}</style>
 
-    {# Add facility for pages to delare an array of critical styles #}
+    {# Add facility for pages to declare an array of critical styles #}
     {% if pageCriticalStyles %}
         {% for item in pageCriticalStyles %}
             <style>{% include item %}</style>


### PR DESCRIPTION
## Summary
- Fix typo in HTML comment: 'delare' → 'declare'

## Test plan
- [x] No functional changes, just a comment fix

Fixes #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)