### PR TITLE
[refactor] Use modern ::before pseudo-element syntax

### DIFF
--- a/src/assets/css/base.scss
+++ b/src/assets/css/base.scss
@@ -123,7 +123,7 @@ a {
   transition: 0.4s;
 }
 
-.slider:before {
+.slider::before {
   position: absolute;
   content: '';
   height: 40px;
@@ -146,7 +146,7 @@ a {
   box-shadow: 0 0 1px #2196f3;
 }
 
-#switch:checked + .body .slider:before {
+#switch:checked + .body .slider::before {
   -webkit-transform: translateX(24px);
   -ms-transform: translateX(24px);
   transform: translateX(24px);
@@ -157,7 +157,7 @@ a {
   border-radius: 34px;
 }
 
-.slider.round:before {
+.slider.round::before {
   border-radius: 50%;
 }
 


### PR DESCRIPTION
## Summary
- Update CSS pseudo-element selectors from single colon (`:before`) to double colon (`::before`) syntax
- Changes apply to `.slider::before` and `.slider.round::before` in base.scss
- Note: `critical.scss` was not modified as it contains vendor normalize code

## Test plan
- [ ] Verify dark/light mode toggle still works correctly
- [ ] Confirm slider appearance is unchanged

Fixes #143

🤖 Generated with [Claude Code](https://claude.com/claude-code)